### PR TITLE
Fixes error output by converting to string.

### DIFF
--- a/bin/ggbgfx-sprite.js
+++ b/bin/ggbgfx-sprite.js
@@ -46,7 +46,7 @@ program
         }
       })
       .catch(function(error) {
-        process.stderr.write(error);
+        process.stderr.write(error.toString());
         process.exit(1);
       });
   });

--- a/bin/ggbgfx-tiledata.js
+++ b/bin/ggbgfx-tiledata.js
@@ -47,7 +47,7 @@ program
         }
       })
       .catch(function(error) {
-        process.stderr.write(error);
+        process.stderr.write(error.toString());
         process.exit(1);
       });
   });

--- a/bin/ggbgfx-tilemap.js
+++ b/bin/ggbgfx-tilemap.js
@@ -56,7 +56,7 @@ program
         }
       })
       .catch(function(error) {
-        process.stderr.write(error);
+        process.stderr.write(error.toString());
         process.exit(1);
       });
   });

--- a/bin/ggbgfx-tileset.js
+++ b/bin/ggbgfx-tileset.js
@@ -17,7 +17,7 @@ program
     }
     var outFile = path.resolve(process.cwd(), program.outfile);
     ggbgfx.imagesToTilesetImage(images, outFile).catch(function(error) {
-      process.stderr.write(error);
+      process.stderr.write(error.toString());
       process.exit(1);
     });
   });


### PR DESCRIPTION
## Description
Changes all thrown `Error` types into `string` in order to avoid a runtime error when calling `process.stderr.write`.

## Steps to Reproduce
1. Download [background.png](https://user-images.githubusercontent.com/442836/77499618-d8422600-6e0f-11ea-8263-f5fb40e59085.png) and [tileset.png](https://user-images.githubusercontent.com/442836/77499646-e98b3280-6e0f-11ea-97bb-a1bde66dc253.png)
    * Note that contents of the `tileset.png` file specifically does not contain the tile necessary to render the `background.png` file.
2. Run the following command
```bash
ggbgfx tilemap -n tiles background.png tileset.png
```

### System Information
```powershell
PS C:\> [System.Environment]::OSVersion.Version

Major  Minor  Build  Revision
-----  -----  -----  --------
10     0      18363  0


PS C:\> node --version
v12.9.1
```

### Expected output
```bash
Error: Tile is missing from tileset: 0xFF,0x88,0xFF,0x00,0xFF,0x22,0xFF,0x00,0xFF,0x88,0xFF,0x00,0xFF,0x22,0xFF,0x00,
```
### Actual output
```bash
(node:22136) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be one of type string or Buffer. Received type object
    at validChunk (_stream_writable.js:265:10)
    at WriteStream.Writable.write (_stream_writable.js:300:21)
    at C:\src\github\emsdk\node\12.9.1_64bit\bin\node_modules\ggbgfx-cli\bin\ggbgfx-tilemap.js:59:24
    at processTicksAndRejections (internal/process/task_queues.js:85:5)
(node:22136) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:22136) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```